### PR TITLE
Add test plan to place edgedevices in namespaces

### DIFF
--- a/scripts/teardown.sh
+++ b/scripts/teardown.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 
-kubectl get edgedevice  -o=custom-columns=NAME:.metadata.name --no-headers | xargs kubectl patch edgedevice -p '{"metadata":{"finalizers":null}}' --type=merge
-kubectl get edgedeployment -o=custom-columns=NAME:.metadata.name --no-headers | xargs kubectl patch edgedeployment -p '{"metadata":{"finalizers":null}}' --type=merge
-oc delete edgedevice --all
-oc delete edgedeployments --all
-oc delete obc --all
+kubectl get edgedevices --all-namespaces --no-headers | awk '{print $2 " --namespace=" $1}' |  xargs -n 2 kubectl patch edgedevice -p '{"metadata":{"finalizers":null}}' --type=merge
+kubectl get edgedeployment --all-namespaces --no-headers | awk '{print $2 " --namespace=" $1}' | xargs -n 2 kubectl patch edgedeployment -p '{"metadata":{"finalizers":null}}' --type=merge
+kubectl delete edgedevice --all --all-namespaces
+kubectl delete edgedeployments --all --all-namespaces
+
+if [ $# -eq 1 ]; then
+    for i in $(seq $1)
+    do
+      kubectl delete ns $((i - 1))
+    done
+fi

--- a/test_plans/flotta_test_plan_multiple_namespaces.jmx
+++ b/test_plans/flotta_test_plan_multiple_namespaces.jmx
@@ -1,0 +1,683 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.4.1">
+  <hashTree>
+    <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="Flotta Test Plan" enabled="true">
+      <stringProp name="TestPlan.comments"></stringProp>
+      <boolProp name="TestPlan.functional_mode">false</boolProp>
+      <boolProp name="TestPlan.tearDown_on_shutdown">true</boolProp>
+      <boolProp name="TestPlan.serialize_threadgroups">true</boolProp>
+      <elementProp name="TestPlan.user_defined_variables" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
+        <collectionProp name="Arguments.arguments"/>
+      </elementProp>
+      <stringProp name="TestPlan.user_define_classpath"></stringProp>
+    </TestPlan>
+    <hashTree>
+      <UserParameters guiclass="UserParametersGui" testclass="UserParameters" testname="User Parameters" enabled="true">
+        <collectionProp name="UserParameters.names">
+          <stringProp name="1480783578">HTTP_SERVER</stringProp>
+          <stringProp name="-1031304506">HTTP_SERVER_PORT</stringProp>
+          <stringProp name="-161397685">OCP_API_SERVER</stringProp>
+          <stringProp name="504779657">OCP_API_PORT</stringProp>
+          <stringProp name="-1135032042">LABEL_NAME</stringProp>
+          <stringProp name="-818867162">LABEL_VALUE</stringProp>
+          <stringProp name="302271645">DEFAULT_NAMESPACE</stringProp>
+          <stringProp name="-671461751">DEPLOYMENTS_PER_DEVICE</stringProp>
+          <stringProp name="1796555880">NAMESPACES_COUNT</stringProp>
+          <stringProp name="0"></stringProp>
+        </collectionProp>
+        <collectionProp name="UserParameters.thread_values">
+          <collectionProp name="-1484066625">
+            <stringProp name="-546850260">${__P(HTTP_SERVER,flotta-operator-controller-manager-flotta-operator-system.apps.mycluster.redhat.com)}</stringProp>
+            <stringProp name="1153133027">${__P(HTTP_SERVER_PORT,80)}</stringProp>
+            <stringProp name="-1649297033">${__P(OCP_API_SERVER,api.mycluster.redhat.com)}</stringProp>
+            <stringProp name="-404799529">${__P(OCP_API_PORT,6443)}</stringProp>
+            <stringProp name="-934795532">region</stringProp>
+            <stringProp name="3116868">emea</stringProp>
+            <stringProp name="1544803905">default</stringProp>
+            <stringProp name="-1692776171">${__P(DEPLOYMENTS_PER_DEVICE,5)}</stringProp>
+            <stringProp name="1897062068">${__P(NAMESPACES_COUNT,5)}</stringProp>
+            <stringProp name="0"></stringProp>
+          </collectionProp>
+        </collectionProp>
+        <boolProp name="UserParameters.per_iteration">false</boolProp>
+      </UserParameters>
+      <hashTree/>
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Create Namespaces" enabled="true">
+        <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
+        <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">
+          <boolProp name="LoopController.continue_forever">false</boolProp>
+          <stringProp name="LoopController.loops">${__P(NAMESPACES_COUNT,5)}</stringProp>
+        </elementProp>
+        <stringProp name="ThreadGroup.num_threads">1</stringProp>
+        <stringProp name="ThreadGroup.ramp_time">1</stringProp>
+        <boolProp name="ThreadGroup.scheduler">false</boolProp>
+        <stringProp name="ThreadGroup.duration"></stringProp>
+        <stringProp name="ThreadGroup.delay"></stringProp>
+        <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
+      </ThreadGroup>
+      <hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="HTTP Request - Create Namespace" enabled="true">
+          <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">{&#xd;
+    &quot;apiVersion&quot;: &quot;v1&quot;,&#xd;
+    &quot;kind&quot;: &quot;Namespace&quot;,&#xd;
+    &quot;metadata&quot;: {&#xd;
+        &quot;name&quot;: &quot;${__BeanShell(vars.getIteration()-1;,)}&quot;&#xd;
+    },&#xd;
+    &quot;spec&quot;: {&#xd;
+    }&#xd;
+}&#xd;
+</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+          <stringProp name="HTTPSampler.domain">${OCP_API_SERVER}</stringProp>
+          <stringProp name="HTTPSampler.port">${OCP_API_PORT}</stringProp>
+          <stringProp name="HTTPSampler.protocol">https</stringProp>
+          <stringProp name="HTTPSampler.contentEncoding">UTF-8</stringProp>
+          <stringProp name="HTTPSampler.path">/api/v1/namespaces</stringProp>
+          <stringProp name="HTTPSampler.method">POST</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+          <stringProp name="HTTPSampler.implementation">HttpClient4</stringProp>
+          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+          <stringProp name="HTTPSampler.response_timeout"></stringProp>
+          <stringProp name="TestPlan.comments">Create Edge Deployment with labels matching for device</stringProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP Header Manager" enabled="true">
+            <collectionProp name="HeaderManager.headers">
+              <elementProp name="" elementType="Header">
+                <stringProp name="Header.name">Content-Type</stringProp>
+                <stringProp name="Header.value">application/json</stringProp>
+              </elementProp>
+              <elementProp name="" elementType="Header">
+                <stringProp name="Header.name">Cache-Control</stringProp>
+                <stringProp name="Header.value">no-cache</stringProp>
+              </elementProp>
+              <elementProp name="" elementType="Header">
+                <stringProp name="Header.name">Authorization</stringProp>
+                <stringProp name="Header.value">Bearer ${__P(K8S_BEARER_TOKEN)} </stringProp>
+              </elementProp>
+            </collectionProp>
+          </HeaderManager>
+          <hashTree/>
+          <DebugPostProcessor guiclass="TestBeanGUI" testclass="DebugPostProcessor" testname="Debug PostProcessor" enabled="true">
+            <boolProp name="displayJMeterProperties">false</boolProp>
+            <boolProp name="displayJMeterVariables">true</boolProp>
+            <boolProp name="displaySamplerProperties">true</boolProp>
+            <boolProp name="displaySystemProperties">false</boolProp>
+          </DebugPostProcessor>
+          <hashTree/>
+        </hashTree>
+      </hashTree>
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Edge Devices" enabled="true">
+        <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
+        <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">
+          <boolProp name="LoopController.continue_forever">false</boolProp>
+          <stringProp name="LoopController.loops">1</stringProp>
+        </elementProp>
+        <stringProp name="ThreadGroup.num_threads">${__P(EDGE_DEVICES_COUNT,10000)}</stringProp>
+        <stringProp name="ThreadGroup.ramp_time">${__P(RAMP_UP_TIME,2000)}</stringProp>
+        <boolProp name="ThreadGroup.scheduler">false</boolProp>
+        <stringProp name="ThreadGroup.duration"></stringProp>
+        <stringProp name="ThreadGroup.delay"></stringProp>
+        <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
+      </ThreadGroup>
+      <hashTree>
+        <OnceOnlyController guiclass="OnceOnlyControllerGui" testclass="OnceOnlyController" testname="Once Only Controller - Set device parameters" enabled="true"/>
+        <hashTree>
+          <JSR223Sampler guiclass="TestBeanGUI" testclass="JSR223Sampler" testname="Init device parameters" enabled="true">
+            <stringProp name="TestPlan.comments">Generates UUID and namespace</stringProp>
+            <stringProp name="cacheKey">true</stringProp>
+            <stringProp name="filename"></stringProp>
+            <stringProp name="parameters"></stringProp>
+            <stringProp name="script">var deviceId = &quot;${__UUID}&quot;;
+vars.put(&quot;DEVICE_ID&quot;, deviceId);
+var nsCountStr = &quot;${__P(NAMESPACES_COUNT,2)}&quot;;
+var nsCount = Integer.valueOf(nsCountStr);
+var ns = String.valueOf(Math.abs(deviceId.substring(0,5).hashCode()) % nsCount);
+vars.put(&quot;NAMESPACE&quot;, ns);
+
+</stringProp>
+            <stringProp name="scriptLanguage">java</stringProp>
+          </JSR223Sampler>
+          <hashTree/>
+        </hashTree>
+        <OnceOnlyController guiclass="OnceOnlyControllerGui" testclass="OnceOnlyController" testname="Once Only Controller - Device Registration" enabled="true"/>
+        <hashTree>
+          <UserParameters guiclass="UserParametersGui" testclass="UserParameters" testname="Generate Device Information" enabled="true">
+            <collectionProp name="UserParameters.names">
+              <stringProp name="-933757957">PRODUCT_NAME</stringProp>
+              <stringProp name="815223286">SERIAL_NAME</stringProp>
+              <stringProp name="482823219">HOSTNAME</stringProp>
+              <stringProp name="-115359763">MAC_ADDRESS1</stringProp>
+              <stringProp name="-115359762">MAC_ADDRESS2</stringProp>
+            </collectionProp>
+            <collectionProp name="UserParameters.thread_values">
+              <collectionProp name="2119464883">
+                <stringProp name="974807112">${__RandomString(10,abcdefg)}</stringProp>
+                <stringProp name="974807112">${__RandomString(10,abcdefg)}</stringProp>
+                <stringProp name="-914205160">${__RandomString(10,abcdefg)}.${__RandomString(5,abcdefg)}.flotta</stringProp>
+                <stringProp name="1355597914">${__RandomString(2, ABCDEF0123456789)}:${__RandomString(2, ABCDEF0123456789)}:${__RandomString(2, ABCDEF0123456789)}:${__RandomString(2, ABCDEF0123456789)}:${__RandomString(2, ABCDEF0123456789)}:${__RandomString(2, ABCDEF0123456789)}</stringProp>
+                <stringProp name="1355597914">${__RandomString(2, ABCDEF0123456789)}:${__RandomString(2, ABCDEF0123456789)}:${__RandomString(2, ABCDEF0123456789)}:${__RandomString(2, ABCDEF0123456789)}:${__RandomString(2, ABCDEF0123456789)}:${__RandomString(2, ABCDEF0123456789)}</stringProp>
+              </collectionProp>
+              <collectionProp name="-1836788680">
+                <stringProp name="0"></stringProp>
+                <stringProp name="0"></stringProp>
+                <stringProp name="0"></stringProp>
+                <stringProp name="0"></stringProp>
+                <stringProp name="0"></stringProp>
+              </collectionProp>
+            </collectionProp>
+            <boolProp name="UserParameters.per_iteration">true</boolProp>
+            <stringProp name="TestPlan.comments">The device ID to be used for the entire scenario of a specific device and additional device properties</stringProp>
+          </UserParameters>
+          <hashTree/>
+          <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Device Registration HTTP Request" enabled="true">
+            <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+            <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+              <collectionProp name="Arguments.arguments">
+                <elementProp name="" elementType="HTTPArgument">
+                  <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                  <stringProp name="Argument.value">{&#xd;
+   &quot;content&quot;: {&#xd;
+       &quot;hardware&quot;: {&#xd;
+           &quot;cpu&quot;: {&#xd;
+               &quot;architecture&quot;: &quot;x86_64&quot;,&#xd;
+               &quot;flags&quot;: [],&#xd;
+               &quot;model_name&quot;: &quot;Intel(R) Core(TM) i7-6820HQ CPU @ 2.70GHz&quot;&#xd;
+           },&#xd;
+           &quot;hostname&quot;: &quot;${HOSTNAME}&quot;,&#xd;
+           &quot;system_vendor&quot;: {&#xd;
+               &quot;manufacturer&quot;: &quot;LENOVO&quot;,&#xd;
+               &quot;product_name&quot;: &quot;${PRODUCT_NAME}&quot;,&#xd;
+               &quot;serial_number&quot;: &quot;${SERIAL_NAME}&quot;&#xd;
+           }&#xd;
+       },&#xd;
+       &quot;os_image_id&quot;: &quot;unknown&quot;&#xd;
+   },&#xd;
+   &quot;directive&quot;: &quot;registration&quot;,&#xd;
+   &quot;message_id&quot;: &quot;${__UUID()}&quot;,&#xd;
+   &quot;sent&quot;: &quot;2021-11-21T14:45:25.271+02:00&quot;,&#xd;
+   &quot;type&quot;: &quot;data&quot;,&#xd;
+   &quot;version&quot;: 1&#xd;
+}</stringProp>
+                  <stringProp name="Argument.metadata">=</stringProp>
+                </elementProp>
+              </collectionProp>
+            </elementProp>
+            <stringProp name="HTTPSampler.domain">${HTTP_SERVER}</stringProp>
+            <stringProp name="HTTPSampler.port">${HTTP_SERVER_PORT}</stringProp>
+            <stringProp name="HTTPSampler.protocol">http</stringProp>
+            <stringProp name="HTTPSampler.contentEncoding">UTF-8</stringProp>
+            <stringProp name="HTTPSampler.path">/api/flotta-management/v1/data/${DEVICE_ID}/out</stringProp>
+            <stringProp name="HTTPSampler.method">POST</stringProp>
+            <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+            <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+            <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+            <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+            <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+            <stringProp name="HTTPSampler.implementation">HttpClient4</stringProp>
+            <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+            <stringProp name="HTTPSampler.response_timeout"></stringProp>
+            <stringProp name="TestPlan.comments">Device Registration</stringProp>
+          </HTTPSamplerProxy>
+          <hashTree>
+            <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP Header Manager" enabled="true">
+              <collectionProp name="HeaderManager.headers">
+                <elementProp name="" elementType="Header">
+                  <stringProp name="Header.name">Content-Type</stringProp>
+                  <stringProp name="Header.value">application/json</stringProp>
+                </elementProp>
+                <elementProp name="" elementType="Header">
+                  <stringProp name="Header.name">Cache-Control</stringProp>
+                  <stringProp name="Header.value">no-cache</stringProp>
+                </elementProp>
+              </collectionProp>
+            </HeaderManager>
+            <hashTree/>
+            <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
+              <collectionProp name="Asserion.test_strings">
+                <stringProp name="1477249802">200 OK</stringProp>
+              </collectionProp>
+              <stringProp name="TestPlan.comments">Verify device was created successfully</stringProp>
+              <stringProp name="Assertion.custom_message"></stringProp>
+              <stringProp name="Assertion.test_field">Assertion.response_headers</stringProp>
+              <boolProp name="Assertion.assume_success">false</boolProp>
+              <intProp name="Assertion.test_type">2</intProp>
+            </ResponseAssertion>
+            <hashTree/>
+            <ResultAction guiclass="ResultActionGui" testclass="ResultAction" testname="Result Status Action Handler" enabled="true">
+              <stringProp name="TestPlan.comments">Stop processing if registration failed</stringProp>
+              <intProp name="OnError.action">1</intProp>
+            </ResultAction>
+            <hashTree/>
+          </hashTree>
+          <ConstantTimer guiclass="ConstantTimerGui" testclass="ConstantTimer" testname="Get Updates Constant Timer" enabled="true">
+            <stringProp name="TestPlan.comments">Add delays between Get Updates requests</stringProp>
+            <stringProp name="ConstantTimer.delay">5000</stringProp>
+          </ConstantTimer>
+          <hashTree/>
+          <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Label Device HTTP Request" enabled="true">
+            <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+            <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+              <collectionProp name="Arguments.arguments">
+                <elementProp name="" elementType="HTTPArgument">
+                  <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                  <stringProp name="Argument.value">{&#xd;
+  &quot;metadata&quot;: {&#xd;
+    &quot;labels&quot;: {&#xd;
+      &quot;${LABEL_NAME}&quot;: &quot;${DEVICE_ID}&quot;&#xd;
+    }&#xd;
+  }&#xd;
+}</stringProp>
+                  <stringProp name="Argument.metadata">=</stringProp>
+                </elementProp>
+              </collectionProp>
+            </elementProp>
+            <stringProp name="HTTPSampler.domain">${OCP_API_SERVER}</stringProp>
+            <stringProp name="HTTPSampler.port">${OCP_API_PORT}</stringProp>
+            <stringProp name="HTTPSampler.protocol">https</stringProp>
+            <stringProp name="HTTPSampler.contentEncoding">UTF-8</stringProp>
+            <stringProp name="HTTPSampler.path">/apis/management.project-flotta.io/v1alpha1/namespaces/${NAMESPACE}/edgedevices/${DEVICE_ID}</stringProp>
+            <stringProp name="HTTPSampler.method">PATCH</stringProp>
+            <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+            <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+            <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+            <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+            <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+            <stringProp name="HTTPSampler.implementation">HttpClient4</stringProp>
+            <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+            <stringProp name="HTTPSampler.response_timeout"></stringProp>
+            <stringProp name="TestPlan.comments">Label device with &apos;region=emea&apos;</stringProp>
+          </HTTPSamplerProxy>
+          <hashTree>
+            <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP Header Manager" enabled="true">
+              <collectionProp name="HeaderManager.headers">
+                <elementProp name="" elementType="Header">
+                  <stringProp name="Header.name">Content-Type</stringProp>
+                  <stringProp name="Header.value">application/merge-patch+json</stringProp>
+                </elementProp>
+                <elementProp name="" elementType="Header">
+                  <stringProp name="Header.name">Cache-Control</stringProp>
+                  <stringProp name="Header.value">no-cache</stringProp>
+                </elementProp>
+                <elementProp name="" elementType="Header">
+                  <stringProp name="Header.name">Authorization</stringProp>
+                  <stringProp name="Header.value">Bearer ${__P(K8S_BEARER_TOKEN)}</stringProp>
+                </elementProp>
+              </collectionProp>
+            </HeaderManager>
+            <hashTree/>
+            <DebugPostProcessor guiclass="TestBeanGUI" testclass="DebugPostProcessor" testname="Debug PostProcessor" enabled="true">
+              <boolProp name="displayJMeterProperties">false</boolProp>
+              <boolProp name="displayJMeterVariables">true</boolProp>
+              <boolProp name="displaySamplerProperties">true</boolProp>
+              <boolProp name="displaySystemProperties">false</boolProp>
+            </DebugPostProcessor>
+            <hashTree/>
+          </hashTree>
+        </hashTree>
+        <OnceOnlyController guiclass="OnceOnlyControllerGui" testclass="OnceOnlyController" testname="Once Only Controller - Create EdgeDeployments" enabled="true"/>
+        <hashTree>
+          <LoopController guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller - Create EdgeDeployments" enabled="true">
+            <boolProp name="LoopController.continue_forever">true</boolProp>
+            <stringProp name="LoopController.loops">${DEPLOYMENTS_PER_DEVICE}</stringProp>
+          </LoopController>
+          <hashTree>
+            <CounterConfig guiclass="CounterConfigGui" testclass="CounterConfig" testname="NameSuffix Counter" enabled="true">
+              <stringProp name="CounterConfig.start">1</stringProp>
+              <stringProp name="CounterConfig.end">10</stringProp>
+              <stringProp name="CounterConfig.incr">1</stringProp>
+              <stringProp name="CounterConfig.name">NameSuffix</stringProp>
+              <stringProp name="CounterConfig.format"></stringProp>
+              <boolProp name="CounterConfig.per_user">true</boolProp>
+              <boolProp name="CounterConfig.reset_on_tg_iteration">true</boolProp>
+            </CounterConfig>
+            <hashTree/>
+            <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="HTTP Request - Create Edge Deployment" enabled="true">
+              <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+              <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+                <collectionProp name="Arguments.arguments">
+                  <elementProp name="" elementType="HTTPArgument">
+                    <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                    <stringProp name="Argument.value">{&#xd;
+    &quot;apiVersion&quot;: &quot;management.project-flotta.io/v1alpha1&quot;,&#xd;
+    &quot;kind&quot;: &quot;EdgeDeployment&quot;,&#xd;
+    &quot;metadata&quot;: {&#xd;
+        &quot;name&quot;: &quot;${DEVICE_ID}-${NameSuffix}&quot;,&#xd;
+        &quot;namespace&quot;: &quot;${NAMESPACE}&quot;&#xd;
+    },&#xd;
+    &quot;spec&quot;: {&#xd;
+        &quot;data&quot;: {&#xd;
+            &quot;paths&quot;: [&#xd;
+                {&#xd;
+                    &quot;source&quot;: &quot;.&quot;,&#xd;
+                    &quot;target&quot;: &quot;nginx&quot;&#xd;
+                }&#xd;
+            ]&#xd;
+        },&#xd;
+        &quot;deviceSelector&quot;: {&#xd;
+            &quot;matchLabels&quot;: {&#xd;
+                &quot;${LABEL_NAME}&quot;: &quot;${DEVICE_ID}&quot;&#xd;
+            }&#xd;
+        },&#xd;
+        &quot;pod&quot;: {&#xd;
+            &quot;spec&quot;: {&#xd;
+                &quot;containers&quot;: [&#xd;
+                    {&#xd;
+                        &quot;image&quot;: &quot;docker.io/nginx:1.14.2&quot;,&#xd;
+                        &quot;name&quot;: &quot;nginx&quot;,&#xd;
+                        &quot;ports&quot;: [&#xd;
+                            {&#xd;
+                                &quot;containerPort&quot;: 80,&#xd;
+                                &quot;hostPort&quot;: 9090,&#xd;
+                                &quot;protocol&quot;: &quot;TCP&quot;&#xd;
+                            }&#xd;
+                        ]&#xd;
+                    }&#xd;
+                ]&#xd;
+            }&#xd;
+        },&#xd;
+        &quot;type&quot;: &quot;pod&quot;&#xd;
+    }&#xd;
+}</stringProp>
+                    <stringProp name="Argument.metadata">=</stringProp>
+                  </elementProp>
+                </collectionProp>
+              </elementProp>
+              <stringProp name="HTTPSampler.domain">${OCP_API_SERVER}</stringProp>
+              <stringProp name="HTTPSampler.port">${OCP_API_PORT}</stringProp>
+              <stringProp name="HTTPSampler.protocol">https</stringProp>
+              <stringProp name="HTTPSampler.contentEncoding">UTF-8</stringProp>
+              <stringProp name="HTTPSampler.path">/apis/management.project-flotta.io/v1alpha1/namespaces/${NAMESPACE}/edgedeployments</stringProp>
+              <stringProp name="HTTPSampler.method">POST</stringProp>
+              <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+              <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+              <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+              <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+              <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+              <stringProp name="HTTPSampler.implementation">HttpClient4</stringProp>
+              <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+              <stringProp name="HTTPSampler.response_timeout"></stringProp>
+              <stringProp name="TestPlan.comments">Create Edge Deployment with labels matching for device</stringProp>
+            </HTTPSamplerProxy>
+            <hashTree>
+              <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP Header Manager" enabled="true">
+                <collectionProp name="HeaderManager.headers">
+                  <elementProp name="" elementType="Header">
+                    <stringProp name="Header.name">Content-Type</stringProp>
+                    <stringProp name="Header.value">application/json</stringProp>
+                  </elementProp>
+                  <elementProp name="" elementType="Header">
+                    <stringProp name="Header.name">Cache-Control</stringProp>
+                    <stringProp name="Header.value">no-cache</stringProp>
+                  </elementProp>
+                  <elementProp name="" elementType="Header">
+                    <stringProp name="Header.name">Authorization</stringProp>
+                    <stringProp name="Header.value">Bearer ${__P(K8S_BEARER_TOKEN)} </stringProp>
+                  </elementProp>
+                </collectionProp>
+              </HeaderManager>
+              <hashTree/>
+              <DebugPostProcessor guiclass="TestBeanGUI" testclass="DebugPostProcessor" testname="Debug PostProcessor" enabled="true">
+                <boolProp name="displayJMeterProperties">false</boolProp>
+                <boolProp name="displayJMeterVariables">true</boolProp>
+                <boolProp name="displaySamplerProperties">true</boolProp>
+                <boolProp name="displaySystemProperties">false</boolProp>
+              </DebugPostProcessor>
+              <hashTree/>
+            </hashTree>
+            <ConstantTimer guiclass="ConstantTimerGui" testclass="ConstantTimer" testname="Pause between edgedeployments creation Constant Timer" enabled="true">
+              <stringProp name="TestPlan.comments">Add delays between edgedeployments creation of the same device</stringProp>
+              <stringProp name="ConstantTimer.delay">1000</stringProp>
+            </ConstantTimer>
+            <hashTree/>
+          </hashTree>
+        </hashTree>
+        <LoopController guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller - Send Heartbeat/Get Updates" enabled="true">
+          <boolProp name="LoopController.continue_forever">true</boolProp>
+          <stringProp name="LoopController.loops">${__P(ITERATIONS,180)}</stringProp>
+        </LoopController>
+        <hashTree>
+          <LoopController guiclass="LoopControlPanel" testclass="LoopController" testname="Get Updates for Edge Device - Loop Controller" enabled="true">
+            <boolProp name="LoopController.continue_forever">true</boolProp>
+            <stringProp name="LoopController.loops">4</stringProp>
+          </LoopController>
+          <hashTree>
+            <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Get Updates HTTP Request" enabled="true">
+              <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
+                <collectionProp name="Arguments.arguments"/>
+              </elementProp>
+              <stringProp name="HTTPSampler.domain">${HTTP_SERVER}</stringProp>
+              <stringProp name="HTTPSampler.port">${HTTP_SERVER_PORT}</stringProp>
+              <stringProp name="HTTPSampler.protocol">http</stringProp>
+              <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+              <stringProp name="HTTPSampler.path">/api/flotta-management/v1/data/${DEVICE_ID}/in</stringProp>
+              <stringProp name="HTTPSampler.method">GET</stringProp>
+              <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+              <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+              <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+              <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+              <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+              <stringProp name="HTTPSampler.implementation">HttpClient4</stringProp>
+              <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+              <stringProp name="HTTPSampler.response_timeout"></stringProp>
+            </HTTPSamplerProxy>
+            <hashTree/>
+            <ConstantTimer guiclass="ConstantTimerGui" testclass="ConstantTimer" testname="Get Updates Constant Timer" enabled="true">
+              <stringProp name="TestPlan.comments">Add delays between Get Updates requests</stringProp>
+              <stringProp name="ConstantTimer.delay">15000</stringProp>
+            </ConstantTimer>
+            <hashTree/>
+          </hashTree>
+          <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Send Heartbeats HTTP Request" enabled="true">
+            <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+            <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+              <collectionProp name="Arguments.arguments">
+                <elementProp name="" elementType="HTTPArgument">
+                  <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                  <stringProp name="Argument.value">{&#xd;
+   &quot;content&quot;: {&#xd;
+       &quot;events&quot;: [&#xd;
+           {&#xd;
+               &quot;message&quot;: &quot;error starting container f8433cc4b0c963ce95625ab3b1811382f852432f61a2d087422210e9d34bc2bc: cannot listen on the TCP port: listen tcp4 :11000: bind: address already in use,error starting container 7cd64802bde9d6b9dd425d79ea68eb49546e5fc87d0dce474c7515e81f448d50: a dependency of container 7cd64802bde9d6b9dd425d79ea68eb49546e5fc87d0dce474c7515e81f448d50 failed to start: container state improper&quot;,&#xd;
+               &quot;reason&quot;: &quot;Failed&quot;,&#xd;
+               &quot;type&quot;: &quot;warn&quot;&#xd;
+           },&#xd;
+           {&#xd;
+               &quot;message&quot;: &quot;error starting container f8433cc4b0c963ce95625ab3b1811382f852432f61a2d087422210e9d34bc2bc: cannot listen on the TCP port: listen tcp4 :11000: bind: address already in use,error starting container 7cd64802bde9d6b9dd425d79ea68eb49546e5fc87d0dce474c7515e81f448d50: a dependency of container 7cd64802bde9d6b9dd425d79ea68eb49546e5fc87d0dce474c7515e81f448d50 failed to start: container state improper&quot;,&#xd;
+               &quot;reason&quot;: &quot;Failed&quot;,&#xd;
+               &quot;type&quot;: &quot;warn&quot;&#xd;
+           },&#xd;
+           {&#xd;
+               &quot;message&quot;: &quot;error starting container f8433cc4b0c963ce95625ab3b1811382f852432f61a2d087422210e9d34bc2bc: cannot listen on the TCP port: listen tcp4 :11000: bind: address already in use,error starting container 7cd64802bde9d6b9dd425d79ea68eb49546e5fc87d0dce474c7515e81f448d50: a dependency of container 7cd64802bde9d6b9dd425d79ea68eb49546e5fc87d0dce474c7515e81f448d50 failed to start: container state improper&quot;,&#xd;
+               &quot;reason&quot;: &quot;Failed&quot;,&#xd;
+               &quot;type&quot;: &quot;warn&quot;&#xd;
+           },&#xd;
+           {&#xd;
+               &quot;message&quot;: &quot;error starting container f8433cc4b0c963ce95625ab3b1811382f852432f61a2d087422210e9d34bc2bc: cannot listen on the TCP port: listen tcp4 :11000: bind: address already in use,error starting container 7cd64802bde9d6b9dd425d79ea68eb49546e5fc87d0dce474c7515e81f448d50: a dependency of container 7cd64802bde9d6b9dd425d79ea68eb49546e5fc87d0dce474c7515e81f448d50 failed to start: container state improper&quot;,&#xd;
+               &quot;reason&quot;: &quot;Failed&quot;,&#xd;
+               &quot;type&quot;: &quot;warn&quot;&#xd;
+           }&#xd;
+       ],&#xd;
+       &quot;status&quot;: &quot;up&quot;,&#xd;
+       &quot;time&quot;: &quot;${__time(yyyy-MM-dd&apos;T&apos;HH:mm:ss.SSS&apos;Z&apos;)}&quot;,&#xd;
+       &quot;version&quot;: &quot;278650&quot;,&#xd;
+       &quot;workloads&quot;: [&#xd;
+           {&#xd;
+               &quot;last_data_upload&quot;: &quot;0001-01-01T00:00:00.000Z&quot;,&#xd;
+               &quot;name&quot;: &quot;${DEVICE_ID}-1&quot;,&#xd;
+               &quot;status&quot;: &quot;Running&quot;&#xd;
+           },&#xd;
+           {&#xd;
+               &quot;last_data_upload&quot;: &quot;0001-01-01T00:00:00.000Z&quot;,&#xd;
+               &quot;name&quot;: &quot;${DEVICE_ID}-2&quot;,&#xd;
+               &quot;status&quot;: &quot;Created&quot;&#xd;
+           },&#xd;
+           {&#xd;
+               &quot;last_data_upload&quot;: &quot;0001-01-01T00:00:00.000Z&quot;,&#xd;
+               &quot;name&quot;: &quot;${DEVICE_ID}-3&quot;,&#xd;
+               &quot;status&quot;: &quot;Running&quot;&#xd;
+           },&#xd;
+           {&#xd;
+               &quot;last_data_upload&quot;: &quot;0001-01-01T00:00:00.000Z&quot;,&#xd;
+               &quot;name&quot;: &quot;${DEVICE_ID}-4&quot;,&#xd;
+               &quot;status&quot;: &quot;Created&quot;&#xd;
+           },&#xd;
+           {&#xd;
+               &quot;last_data_upload&quot;: &quot;0001-01-01T00:00:00.000Z&quot;,&#xd;
+               &quot;name&quot;: &quot;${DEVICE_ID}-5&quot;,&#xd;
+               &quot;status&quot;: &quot;Running&quot;&#xd;
+           },&#xd;
+           {&#xd;
+               &quot;last_data_upload&quot;: &quot;0001-01-01T00:00:00.000Z&quot;,&#xd;
+               &quot;name&quot;: &quot;${DEVICE_ID}-6&quot;,&#xd;
+               &quot;status&quot;: &quot;Created&quot;&#xd;
+           },&#xd;
+           {&#xd;
+               &quot;last_data_upload&quot;: &quot;0001-01-01T00:00:00.000Z&quot;,&#xd;
+               &quot;name&quot;: &quot;${DEVICE_ID}-7&quot;,&#xd;
+               &quot;status&quot;: &quot;Running&quot;&#xd;
+           },&#xd;
+           {&#xd;
+               &quot;last_data_upload&quot;: &quot;0001-01-01T00:00:00.000Z&quot;,&#xd;
+               &quot;name&quot;: &quot;${DEVICE_ID}-8&quot;,&#xd;
+               &quot;status&quot;: &quot;Created&quot;&#xd;
+           },&#xd;
+           {&#xd;
+               &quot;last_data_upload&quot;: &quot;0001-01-01T00:00:00.000Z&quot;,&#xd;
+               &quot;name&quot;: &quot;${DEVICE_ID}-9&quot;,&#xd;
+               &quot;status&quot;: &quot;Running&quot;&#xd;
+           }&#xd;
+       ]&#xd;
+   },&#xd;
+   &quot;directive&quot;: &quot;heartbeat&quot;,&#xd;
+   &quot;message_id&quot;: &quot;${__UUID()}&quot;,&#xd;
+   &quot;type&quot;: &quot;data&quot;,&#xd;
+   &quot;version&quot;: 1&#xd;
+}</stringProp>
+                  <stringProp name="Argument.metadata">=</stringProp>
+                </elementProp>
+              </collectionProp>
+            </elementProp>
+            <stringProp name="HTTPSampler.domain">${HTTP_SERVER}</stringProp>
+            <stringProp name="HTTPSampler.port">${HTTP_SERVER_PORT}</stringProp>
+            <stringProp name="HTTPSampler.protocol">http</stringProp>
+            <stringProp name="HTTPSampler.contentEncoding">UTF-8</stringProp>
+            <stringProp name="HTTPSampler.path">/api/flotta-management/v1/data/${DEVICE_ID}/out</stringProp>
+            <stringProp name="HTTPSampler.method">POST</stringProp>
+            <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+            <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+            <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+            <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+            <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+            <stringProp name="HTTPSampler.implementation">HttpClient4</stringProp>
+            <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+            <stringProp name="HTTPSampler.response_timeout"></stringProp>
+            <stringProp name="TestPlan.comments">Send Heartbeats</stringProp>
+          </HTTPSamplerProxy>
+          <hashTree>
+            <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP Header Manager" enabled="true">
+              <collectionProp name="HeaderManager.headers">
+                <elementProp name="" elementType="Header">
+                  <stringProp name="Header.name">content-type</stringProp>
+                  <stringProp name="Header.value">application/json</stringProp>
+                </elementProp>
+              </collectionProp>
+            </HeaderManager>
+            <hashTree/>
+          </hashTree>
+          <ConstantTimer guiclass="ConstantTimerGui" testclass="ConstantTimer" testname="Get Updates Constant Timer" enabled="true">
+            <stringProp name="TestPlan.comments">Add delays between iterations</stringProp>
+            <stringProp name="ConstantTimer.delay">2000</stringProp>
+          </ConstantTimer>
+          <hashTree/>
+        </hashTree>
+      </hashTree>
+      <ResultCollector guiclass="TableVisualizer" testclass="ResultCollector" testname="View Results in Table" enabled="false">
+        <boolProp name="ResultCollector.error_logging">false</boolProp>
+        <objProp>
+          <name>saveConfig</name>
+          <value class="SampleSaveConfiguration">
+            <time>true</time>
+            <latency>true</latency>
+            <timestamp>true</timestamp>
+            <success>true</success>
+            <label>true</label>
+            <code>true</code>
+            <message>true</message>
+            <threadName>true</threadName>
+            <dataType>true</dataType>
+            <encoding>false</encoding>
+            <assertions>true</assertions>
+            <subresults>true</subresults>
+            <responseData>false</responseData>
+            <samplerData>false</samplerData>
+            <xml>false</xml>
+            <fieldNames>true</fieldNames>
+            <responseHeaders>false</responseHeaders>
+            <requestHeaders>false</requestHeaders>
+            <responseDataOnError>false</responseDataOnError>
+            <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+            <assertionsResultsToSave>0</assertionsResultsToSave>
+            <bytes>true</bytes>
+            <sentBytes>true</sentBytes>
+            <url>true</url>
+            <threadCounts>true</threadCounts>
+            <idleTime>true</idleTime>
+            <connectTime>true</connectTime>
+          </value>
+        </objProp>
+        <stringProp name="filename"></stringProp>
+      </ResultCollector>
+      <hashTree/>
+      <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="false">
+        <boolProp name="ResultCollector.error_logging">false</boolProp>
+        <objProp>
+          <name>saveConfig</name>
+          <value class="SampleSaveConfiguration">
+            <time>true</time>
+            <latency>true</latency>
+            <timestamp>true</timestamp>
+            <success>true</success>
+            <label>true</label>
+            <code>true</code>
+            <message>true</message>
+            <threadName>true</threadName>
+            <dataType>true</dataType>
+            <encoding>false</encoding>
+            <assertions>true</assertions>
+            <subresults>true</subresults>
+            <responseData>false</responseData>
+            <samplerData>false</samplerData>
+            <xml>false</xml>
+            <fieldNames>true</fieldNames>
+            <responseHeaders>false</responseHeaders>
+            <requestHeaders>false</requestHeaders>
+            <responseDataOnError>false</responseDataOnError>
+            <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+            <assertionsResultsToSave>0</assertionsResultsToSave>
+            <bytes>true</bytes>
+            <sentBytes>true</sentBytes>
+            <url>true</url>
+            <threadCounts>true</threadCounts>
+            <idleTime>true</idleTime>
+            <connectTime>true</connectTime>
+          </value>
+        </objProp>
+        <stringProp name="filename"></stringProp>
+      </ResultCollector>
+      <hashTree/>
+    </hashTree>
+  </hashTree>
+</jmeterTestPlan>


### PR DESCRIPTION
Since specifying namespace for edge devices isn't yet supported by
flotta-operator, a hacked version is used for testing.

The distribution of edge devices across namespaces might not be
perfectly balanced.

Since there is a need to match between values produced by JMeter test
plan and operator logic, the device ID is being used:
(hashCode of first 6 chars of egde device ID) % number of namespaces.

The same logic is implemented on the operator side.

teardown.sh script was updated to support clearing of devices and
deployments from multiple namespaces.

Signed-off-by: Moti Asayag <masayag@redhat.com>