### PR TITLE
Specify when namespaces are not used

### DIFF
--- a/scripts/run_test_plan.sh
+++ b/scripts/run_test_plan.sh
@@ -172,7 +172,7 @@ fi
 
 if [[ -z $NAMESPACES_COUNT ]]; then
     RUN_WITHOUT_NAMESPACES=1
-    NAMESPACES_COUNT="10"
+    NAMESPACES_COUNT="0"
     echo "INFO: Namespaces not specified. Using default value: $NAMESPACES_COUNT"
 fi
 


### PR DESCRIPTION
By using NAMESPACES_COUNT=0 the operator will now to place the
edgedevices in the default namespace.

Signed-off-by: Moti Asayag <masayag@redhat.com>